### PR TITLE
Allow 'search_type' as an attribute

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -59,6 +59,13 @@ func validateAttributes(attributes map[string]string) (string, int, error) {
 	}
 	delete(attributes, "menu_order")
 
+	if searchType, found := attributes["search_type"]; found {
+		if searchType == "" {
+			return "", 0, fmt.Errorf("empty search_type attribute")
+		}
+		delete(attributes, "search_type")
+	}
+
 	if len(attributes) > 0 {
 		return "", 0, fmt.Errorf("unknown attributes: %v", attributes)
 	}


### PR DESCRIPTION
This was added in weaveworks/weave#2925 so we need to not barf on it.